### PR TITLE
AttendanceAccessorを実装し、アプリまでデータを送る

### DIFF
--- a/Qt/EARC/app/EARC/App/mainwindow.h
+++ b/Qt/EARC/app/EARC/App/mainwindow.h
@@ -20,5 +20,6 @@ private slots:
 
 private:
     Ui::MainWindow *ui;
+    void readData(const QString &filePath);
 };
 #endif // MAINWINDOW_H

--- a/Qt/EARC/app/EARC/AttendanceAccessor/AttendanceAccessor.pro
+++ b/Qt/EARC/app/EARC/AttendanceAccessor/AttendanceAccessor.pro
@@ -12,11 +12,15 @@ CONFIG += c++11
 
 SOURCES += \
     attendanceaccessor.cpp \
+    attendancedata.cpp \
+    attendancedataconverter.cpp \
     excelaccessoractiveqt.cpp
 
 HEADERS += \
     AttendanceAccessor_global.h \
     attendanceaccessor.h \
+    attendancedata.h \
+    attendancedataconverter.h \
     excelaccessoractiveqt.h
 
 DESTDIR = ../bin

--- a/Qt/EARC/app/EARC/AttendanceAccessor/attendanceaccessor.cpp
+++ b/Qt/EARC/app/EARC/AttendanceAccessor/attendanceaccessor.cpp
@@ -1,13 +1,123 @@
 #include "attendanceaccessor.h"
+#include "attendancedataconverter.h"
+#include "excelaccessoractiveqt.h"
+#include "excelaccessorodbc.h"
 
 #include <QDebug>
 
-AttendanceAccessor::AttendanceAccessor()
+AttendanceAccessor::AttendanceAccessor(QObject *parent)
+    : QObject(parent),
+      excelAccessor(nullptr)
 {
 }
 
-bool AttendanceAccessor::readCells(const QString &filePath, const QString &sheetName, QList<QList<QString> > &list)
+void AttendanceAccessor::readCells()
 {
-    qDebug() << "readCells";
-    return true;
+    connect(excelAccessor.get(), &ExcelAccessor::sendExcelData,
+            this,
+            [=](const QList<QList<QString>> &excelData){
+        qDebug() << "excelData=" << excelData;
+        QList<AttendanceData> attendanceList;
+        AttendanceDataConverter converter;
+        for (auto &row : excelData) {
+            AttendanceData data;
+            data.setDate(converter.toDate(row[0]));
+            data.setDayOfWeek(row[1]);
+            data.setStartTime(converter.toTime(row[2]));
+            data.setEndTime(converter.toTime(row[3]));
+            data.setBreakTime(converter.toTime(row[4]));
+            data.setContents(row[6]);
+            attendanceList << data;
+        }
+        emit sendAttendanceData(attendanceList);
+    });
+    connect(excelAccessor.get(), &ExcelAccessor::readError,
+            this,
+            &AttendanceAccessor::readError);
+    excelAccessor->readCells();
 }
+
+void AttendanceAccessor::setExcelAccessor(ExcelAccessor *accessor)
+{
+    excelAccessor.reset(accessor);
+}
+
+AttendanceAccessor *AttendanceAccessor::Builder::create()
+{
+    AttendanceAccessor *attendanceAccessor = new AttendanceAccessor;
+    switch(builderType) {
+    case BuilderType::ActiveQt:
+    {
+        ExcelAccessorActiveQtReadParam param(
+                    filePath,
+                    sheetNo,
+                    rowStartNo,
+                    rowNum,
+                    columnStartNo,
+                    columnNum);
+        attendanceAccessor->setExcelAccessor(new ExcelAccessorActiveQt(param));
+    }
+        break;
+    case BuilderType::Odbc:
+    {
+        ExcelAccessorOdbcParam param(
+                    filePath,
+                    sheetName,
+                    rowStartNo,
+                    columnNum);
+        attendanceAccessor->setExcelAccessor(new ExcelAccessorOdbc(param));
+    }
+        break;
+    }
+    return attendanceAccessor;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setBuilderType(BuilderType newBuilderType)
+{
+    builderType = newBuilderType;
+    return this;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setFilePath(const QString &newFilePath)
+{
+    filePath = newFilePath;
+    return this;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setSheetName(const QString &newSheetName)
+{
+    sheetName = newSheetName;
+    return this;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setSheetNo(int newSheetNo)
+{
+    sheetNo = newSheetNo;
+    return this;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setRowStartNo(int newRowStartNo)
+{
+    rowStartNo = newRowStartNo;
+    return this;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setRowNum(int newRowNum)
+{
+    rowNum = newRowNum;
+    return this;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setColumnNum(int newColumnNum)
+{
+    columnNum = newColumnNum;
+    return this;
+}
+
+AttendanceAccessor::Builder* AttendanceAccessor::Builder::setColumnStartNo(int newColumnStartNo)
+{
+    columnStartNo = newColumnStartNo;
+    return this;
+}
+
+

--- a/Qt/EARC/app/EARC/AttendanceAccessor/attendanceaccessor.h
+++ b/Qt/EARC/app/EARC/AttendanceAccessor/attendanceaccessor.h
@@ -2,12 +2,50 @@
 #define ATTENDANCEACCESSOR_H
 
 #include "AttendanceAccessor_global.h"
+#include "attendancedata.h"
+#include "excelaccessor.h"
+#include <cstdlib>
+#include <QObject>
 
-class ATTENDANCEACCESSOR_EXPORT AttendanceAccessor
+class ATTENDANCEACCESSOR_EXPORT AttendanceAccessor : public QObject
 {
+    Q_OBJECT
 public:
-    AttendanceAccessor();
-    bool readCells(const QString &filePath, const QString &sheetName, QList<QList<QString>> &list);
+    enum class BuilderType : int {
+        ActiveQt,
+        Odbc
+    };
+    class ATTENDANCEACCESSOR_EXPORT Builder {
+    public:
+        AttendanceAccessor* create();
+        Builder* setBuilderType(BuilderType newBuilderType);
+        Builder* setFilePath(const QString &newFilePath);
+        Builder* setSheetName(const QString &newSheetName);
+        Builder* setSheetNo(int newSheetNo);
+        Builder* setRowStartNo(int newRowStartNo);
+        Builder* setRowNum(int newRowNum);
+        Builder* setColumnNum(int newColumnNum);
+        Builder* setColumnStartNo(int newColumnStartNo);
+    private:
+        BuilderType builderType = BuilderType::Odbc;
+        QString filePath;
+        QString sheetName;
+        int sheetNo = 0;
+        int rowStartNo = 0;
+        int rowNum = 0;
+        int columnNum = 0;
+        int columnStartNo = 0;
+    };
+
+public:
+    AttendanceAccessor(QObject *parent = nullptr);
+    void readCells();
+    void setExcelAccessor(ExcelAccessor *accessor);
+signals:
+    void sendAttendanceData(const QList<AttendanceData> &attendanceDataList);
+    void readError(const QString &reason);
+private:
+    std::unique_ptr<ExcelAccessor> excelAccessor;
 };
 
 #endif // ATTENDANCEACCESSOR_H

--- a/Qt/EARC/app/EARC/AttendanceAccessor/attendancedata.cpp
+++ b/Qt/EARC/app/EARC/AttendanceAccessor/attendancedata.cpp
@@ -1,0 +1,77 @@
+#include "attendancedata.h"
+
+AttendanceData::AttendanceData()
+{
+
+}
+
+QString AttendanceData::toString()
+{
+    return QString("%1,%2,%3,%4,%5,%6")
+            .arg(date.toString("M/d"),
+                 dayOfWeek,
+                 startTime.toString(),
+                 endTime.toString(),
+                 breakTime.toString(),
+                 contents);
+}
+
+const QDate &AttendanceData::getDate() const
+{
+    return date;
+}
+
+void AttendanceData::setDate(const QDate &newDate)
+{
+    date = newDate;
+}
+
+const QString &AttendanceData::getDayOfWeek() const
+{
+    return dayOfWeek;
+}
+
+void AttendanceData::setDayOfWeek(const QString &newDayOfWeek)
+{
+    dayOfWeek = newDayOfWeek;
+}
+
+const QTime &AttendanceData::getStartTime() const
+{
+    return startTime;
+}
+
+void AttendanceData::setStartTime(const QTime &newStartTime)
+{
+    startTime = newStartTime;
+}
+
+const QTime &AttendanceData::getEndTime() const
+{
+    return endTime;
+}
+
+void AttendanceData::setEndTime(const QTime &newEndTime)
+{
+    endTime = newEndTime;
+}
+
+const QTime &AttendanceData::getBreakTime() const
+{
+    return breakTime;
+}
+
+void AttendanceData::setBreakTime(const QTime &newBreakTime)
+{
+    breakTime = newBreakTime;
+}
+
+const QString &AttendanceData::getContents() const
+{
+    return contents;
+}
+
+void AttendanceData::setContents(const QString &newContents)
+{
+    contents = newContents;
+}

--- a/Qt/EARC/app/EARC/AttendanceAccessor/attendancedata.h
+++ b/Qt/EARC/app/EARC/AttendanceAccessor/attendancedata.h
@@ -1,0 +1,34 @@
+#ifndef ATTENDANCEDATA_H
+#define ATTENDANCEDATA_H
+
+#include "AttendanceAccessor_global.h"
+#include <QDate>
+
+class ATTENDANCEACCESSOR_EXPORT AttendanceData
+{
+public:
+    AttendanceData();
+    QString toString();
+    const QDate &getDate() const;
+    void setDate(const QDate &newDate);
+    const QString &getDayOfWeek() const;
+    void setDayOfWeek(const QString &newDayOfWeek);
+    const QTime &getStartTime() const;
+    void setStartTime(const QTime &newStartTime);
+    const QTime &getEndTime() const;
+    void setEndTime(const QTime &newEndTime);
+    const QTime &getBreakTime() const;
+    void setBreakTime(const QTime &newBreakTime);
+    const QString &getContents() const;
+    void setContents(const QString &newContents);
+
+private:
+    QDate date;
+    QString dayOfWeek;
+    QTime startTime;
+    QTime endTime;
+    QTime breakTime;
+    QString contents;
+};
+
+#endif // ATTENDANCEDATA_H

--- a/Qt/EARC/app/EARC/AttendanceAccessor/attendancedataconverter.cpp
+++ b/Qt/EARC/app/EARC/AttendanceAccessor/attendancedataconverter.cpp
@@ -1,0 +1,24 @@
+#include "attendancedataconverter.h"
+
+AttendanceDataConverter::AttendanceDataConverter()
+{
+
+}
+
+QDate AttendanceDataConverter::toDate(const QString &strData)
+{
+    QDate date;
+    if (!strData.isEmpty()) {
+        date = QDate::fromString(strData, "M/d");
+    }
+    return date;
+}
+
+QTime AttendanceDataConverter::toTime(const QString &strData)
+{
+    QTime time;
+    if (!strData.isEmpty()) {
+        time = QTime::fromString(strData, "H/m");
+    }
+    return time;
+}

--- a/Qt/EARC/app/EARC/AttendanceAccessor/attendancedataconverter.h
+++ b/Qt/EARC/app/EARC/AttendanceAccessor/attendancedataconverter.h
@@ -1,0 +1,14 @@
+#ifndef ATTENDANCEDATACONVERTER_H
+#define ATTENDANCEDATACONVERTER_H
+
+#include <QTime>
+
+class AttendanceDataConverter
+{
+public:
+    AttendanceDataConverter();
+    QDate toDate(const QString &strData);
+    QTime toTime(const QString &strData);
+};
+
+#endif // ATTENDANCEDATACONVERTER_H

--- a/Qt/EARC/app/EARC/AttendanceAccessorTest/tst_attendanceaccessortest.cpp
+++ b/Qt/EARC/app/EARC/AttendanceAccessorTest/tst_attendanceaccessortest.cpp
@@ -41,8 +41,8 @@ void AttendanceAccessorTest::cleanupTestCase()
 void AttendanceAccessorTest::test_case1()
 {
     QList<QList<QString>> list;
-    auto ret = accessor->readCells("", "", list);
-    QVERIFY(ret);
+    accessor->readCells();
+//    QVERIFY(ret);
 }
 
 QTEST_APPLESS_MAIN(AttendanceAccessorTest)


### PR DESCRIPTION
## 対応内容
AttendanceAccessorを実装し、アプリまでデータを送る。
AttendanceConverterでデータを変換し、AttendanceAccessorでAttendanceDataクラスに値をセットする。
セットした値をアプリにシグナルで送る。

## Issue: closes #8
